### PR TITLE
Make `uniqueLettersMinLength` optional

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@
 export interface IRequirement {
   minLength?: number | IMessage;
   maxLength?: number | IMessage;
-  uniqueLettersMinLength: number | IMessage;
+  uniqueLettersMinLength?: number | IMessage;
   uppercaseLettersMinLength?: number | IMessage;
   lowercaseLettersMinLength?: number | IMessage;
   numbersMinLength?: number | IMessage;


### PR DESCRIPTION
The new field `uniqueLettersMinLength` that was added in #4 should be optional.