### PR TITLE
Feature/Skip Requirements option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ console.log(JSON.stringify(new PasswordMeter({
     include: ['a', '$'],
     exclude: ['1baA$', '0xaZ$'],
     startsWith: '1',
-    endsWith: '$'
+    endsWith: '$',
     includeOne: ['$']
 }, {
         "40": "veryWeak",    // 001 <= x <  040
@@ -108,7 +108,7 @@ console.log(JSON.stringify(new PasswordMeter({
     include: { value: ['a', '$'], message: "Hey!, check include(s)" },
     exclude: { value: ['1baA$', '0xaZ$'], message: "Hey!, check exclude(s)" },
     startsWith: { value: '1', message: "Hey!, check startsWith" },
-    endsWith: { value: '$', message: "Hey!, check endsWith" }
+    endsWith: { value: '$', message: "Hey!, check endsWith" },
     includeOne: { value: ['$'], message: "Hey!, check includeOne" }
 }, {
         "40": "veryWeak",    // 001 <= x <  040

--- a/README.md
+++ b/README.md
@@ -147,6 +147,20 @@ console.log(JSON.stringify(new PasswordMeter({
 ]    
 ```
 
+### new in version 3.7
+
+In `getResult(password: string, ignoreCase: boolean = false, skipReq: boolean = false))` `skipReq` was added
+With this option we could provide a "score" to our users based on the current 
+typed password (even if they aren't according to requirements).
+
+```typescript
+console.log(JSON.stringify(new PasswordMeter({ 
+    uniqueLettersMinLength: { value: 5, message: "Hey!, check uniqMinLength" } 
+  }).getResult('aZ&4aZ&4', false, true)));
+// result
+{"score":124,"status":"strong","percent":62,"errors":["Hey!, check uniqMinLength"]}
+```
+
 ### new in version 3.6
 
 `includeOne` added.

--- a/dist/amd/index.d.ts
+++ b/dist/amd/index.d.ts
@@ -65,6 +65,6 @@ export declare class PasswordMeter {
     private getSequentialSymbolsScore;
     private getRepeatCharactersScore;
     private getRequirementsScore;
-    getResults(passwords: string[], ignoreCase?: boolean): IResult[];
-    getResult(password: string, ignoreCase?: boolean): IResult;
+    getResults(passwords: string[], ignoreCase?: boolean, skipReq?: boolean): IResult[];
+    getResult(password: string, ignoreCase?: boolean, skipReq?: boolean): IResult;
 }

--- a/dist/amd/index.js
+++ b/dist/amd/index.js
@@ -654,22 +654,24 @@ define(["require", "exports"], function (require, exports) {
             }
             return [];
         };
-        PasswordMeter.prototype.getResults = function (passwords, ignoreCase) {
+        PasswordMeter.prototype.getResults = function (passwords, ignoreCase, skipReq) {
             if (ignoreCase === void 0) { ignoreCase = false; }
+            if (skipReq === void 0) { skipReq = false; }
             var results = [];
             if (passwords && passwords.length > 0) {
                 for (var index = 0; index < passwords.length; index++) {
-                    results.push(this.getResult(passwords[index], ignoreCase));
+                    results.push(this.getResult(passwords[index], ignoreCase, skipReq));
                 }
                 return results;
             }
             return [];
         };
-        PasswordMeter.prototype.getResult = function (password, ignoreCase) {
+        PasswordMeter.prototype.getResult = function (password, ignoreCase, skipReq) {
             if (ignoreCase === void 0) { ignoreCase = false; }
+            if (skipReq === void 0) { skipReq = false; }
             if (password) {
                 var req = this.getRequirementsScore(password, ignoreCase);
-                if (req.length != 0) {
+                if (!skipReq && req.length) {
                     return {
                         score: -1,
                         status: "needs requirement(s)",
@@ -766,11 +768,15 @@ define(["require", "exports"], function (require, exports) {
                     }
                 }
                 var percent = (score * 100) / parseFloat(range[range.length - 2]);
-                return {
+                var data = {
                     score: score,
                     status: stat,
                     percent: percent >= 100 ? 100 : percent,
                 };
+                if (skipReq) {
+                    data = Object.assign(data, { errors: req });
+                }
+                return data;
             }
             return {
                 score: 0,

--- a/dist/commonjs/index.d.ts
+++ b/dist/commonjs/index.d.ts
@@ -65,6 +65,6 @@ export declare class PasswordMeter {
     private getSequentialSymbolsScore;
     private getRepeatCharactersScore;
     private getRequirementsScore;
-    getResults(passwords: string[], ignoreCase?: boolean): IResult[];
-    getResult(password: string, ignoreCase?: boolean): IResult;
+    getResults(passwords: string[], ignoreCase?: boolean, skipReq?: boolean): IResult[];
+    getResult(password: string, ignoreCase?: boolean, skipReq?: boolean): IResult;
 }

--- a/dist/commonjs/index.js
+++ b/dist/commonjs/index.js
@@ -653,22 +653,24 @@ var PasswordMeter = (function () {
         }
         return [];
     };
-    PasswordMeter.prototype.getResults = function (passwords, ignoreCase) {
+    PasswordMeter.prototype.getResults = function (passwords, ignoreCase, skipReq) {
         if (ignoreCase === void 0) { ignoreCase = false; }
+        if (skipReq === void 0) { skipReq = false; }
         var results = [];
         if (passwords && passwords.length > 0) {
             for (var index = 0; index < passwords.length; index++) {
-                results.push(this.getResult(passwords[index], ignoreCase));
+                results.push(this.getResult(passwords[index], ignoreCase, skipReq));
             }
             return results;
         }
         return [];
     };
-    PasswordMeter.prototype.getResult = function (password, ignoreCase) {
+    PasswordMeter.prototype.getResult = function (password, ignoreCase, skipReq) {
         if (ignoreCase === void 0) { ignoreCase = false; }
+        if (skipReq === void 0) { skipReq = false; }
         if (password) {
             var req = this.getRequirementsScore(password, ignoreCase);
-            if (req.length != 0) {
+            if (!skipReq && req.length) {
                 return {
                     score: -1,
                     status: "needs requirement(s)",
@@ -765,11 +767,15 @@ var PasswordMeter = (function () {
                 }
             }
             var percent = (score * 100) / parseFloat(range[range.length - 2]);
-            return {
+            var data = {
                 score: score,
                 status: stat,
                 percent: percent >= 100 ? 100 : percent,
             };
+            if (skipReq) {
+                data = Object.assign(data, { errors: req });
+            }
+            return data;
         }
         return {
             score: 0,

--- a/dist/es2015/index.d.ts
+++ b/dist/es2015/index.d.ts
@@ -65,6 +65,6 @@ export declare class PasswordMeter {
     private getSequentialSymbolsScore;
     private getRepeatCharactersScore;
     private getRequirementsScore;
-    getResults(passwords: string[], ignoreCase?: boolean): IResult[];
-    getResult(password: string, ignoreCase?: boolean): IResult;
+    getResults(passwords: string[], ignoreCase?: boolean, skipReq?: boolean): IResult[];
+    getResult(password: string, ignoreCase?: boolean, skipReq?: boolean): IResult;
 }

--- a/dist/es2015/index.js
+++ b/dist/es2015/index.js
@@ -650,22 +650,24 @@ var PasswordMeter = (function () {
         }
         return [];
     };
-    PasswordMeter.prototype.getResults = function (passwords, ignoreCase) {
+    PasswordMeter.prototype.getResults = function (passwords, ignoreCase, skipReq) {
         if (ignoreCase === void 0) { ignoreCase = false; }
+        if (skipReq === void 0) { skipReq = false; }
         var results = [];
         if (passwords && passwords.length > 0) {
             for (var index = 0; index < passwords.length; index++) {
-                results.push(this.getResult(passwords[index], ignoreCase));
+                results.push(this.getResult(passwords[index], ignoreCase, skipReq));
             }
             return results;
         }
         return [];
     };
-    PasswordMeter.prototype.getResult = function (password, ignoreCase) {
+    PasswordMeter.prototype.getResult = function (password, ignoreCase, skipReq) {
         if (ignoreCase === void 0) { ignoreCase = false; }
+        if (skipReq === void 0) { skipReq = false; }
         if (password) {
             var req = this.getRequirementsScore(password, ignoreCase);
-            if (req.length != 0) {
+            if (!skipReq && req.length) {
                 return {
                     score: -1,
                     status: "needs requirement(s)",
@@ -762,11 +764,15 @@ var PasswordMeter = (function () {
                 }
             }
             var percent = (score * 100) / parseFloat(range[range.length - 2]);
-            return {
+            var data = {
                 score: score,
                 status: stat,
                 percent: percent >= 100 ? 100 : percent,
             };
+            if (skipReq) {
+                data = Object.assign(data, { errors: req });
+            }
+            return data;
         }
         return {
             score: 0,

--- a/dist/system/index.d.ts
+++ b/dist/system/index.d.ts
@@ -65,6 +65,6 @@ export declare class PasswordMeter {
     private getSequentialSymbolsScore;
     private getRepeatCharactersScore;
     private getRequirementsScore;
-    getResults(passwords: string[], ignoreCase?: boolean): IResult[];
-    getResult(password: string, ignoreCase?: boolean): IResult;
+    getResults(passwords: string[], ignoreCase?: boolean, skipReq?: boolean): IResult[];
+    getResult(password: string, ignoreCase?: boolean, skipReq?: boolean): IResult;
 }

--- a/dist/system/index.js
+++ b/dist/system/index.js
@@ -657,22 +657,24 @@ System.register([], function (exports_1, context_1) {
                     }
                     return [];
                 };
-                PasswordMeter.prototype.getResults = function (passwords, ignoreCase) {
+                PasswordMeter.prototype.getResults = function (passwords, ignoreCase, skipReq) {
                     if (ignoreCase === void 0) { ignoreCase = false; }
+                    if (skipReq === void 0) { skipReq = false; }
                     var results = [];
                     if (passwords && passwords.length > 0) {
                         for (var index = 0; index < passwords.length; index++) {
-                            results.push(this.getResult(passwords[index], ignoreCase));
+                            results.push(this.getResult(passwords[index], ignoreCase, skipReq));
                         }
                         return results;
                     }
                     return [];
                 };
-                PasswordMeter.prototype.getResult = function (password, ignoreCase) {
+                PasswordMeter.prototype.getResult = function (password, ignoreCase, skipReq) {
                     if (ignoreCase === void 0) { ignoreCase = false; }
+                    if (skipReq === void 0) { skipReq = false; }
                     if (password) {
                         var req = this.getRequirementsScore(password, ignoreCase);
-                        if (req.length != 0) {
+                        if (!skipReq && req.length) {
                             return {
                                 score: -1,
                                 status: "needs requirement(s)",
@@ -769,11 +771,15 @@ System.register([], function (exports_1, context_1) {
                             }
                         }
                         var percent = (score * 100) / parseFloat(range[range.length - 2]);
-                        return {
+                        var data = {
                             score: score,
                             status: stat,
                             percent: percent >= 100 ? 100 : percent,
                         };
+                        if (skipReq) {
+                            data = Object.assign(data, { errors: req });
+                        }
+                        return data;
                     }
                     return {
                         score: 0,

--- a/index.ts
+++ b/index.ts
@@ -703,23 +703,24 @@ export class PasswordMeter {
 
   public getResults(
     passwords: string[],
-    ignoreCase: boolean = false
+    ignoreCase: boolean = false,
+    skipReq: boolean = false
   ): IResult[] {
     let results = [];
     if (passwords && passwords.length > 0) {
       for (let index = 0; index < passwords.length; index++) {
-        results.push(this.getResult(passwords[index], ignoreCase));
+        results.push(this.getResult(passwords[index], ignoreCase, skipReq));
       }
       return results;
     }
     return [];
   }
 
-  public getResult(password: string, ignoreCase: boolean = false): IResult {
+  public getResult(password: string, ignoreCase: boolean = false, skipReq: boolean = false): IResult {
     if (password) {
       // Requirements
       let req = this.getRequirementsScore(password, ignoreCase);
-      if (req.length != 0) {
+      if (!skipReq && req.length) {
         return {
           score: -1,
           status: "needs requirement(s)",
@@ -832,11 +833,17 @@ export class PasswordMeter {
       }
       let percent = (score * 100) / parseFloat(range[range.length - 2]);
 
-      return {
+      let data = {
         score: score,
         status: stat,
         percent: percent >= 100 ? 100 : percent,
       };
+
+      if (skipReq) {
+        data = Object.assign(data, { errors: req });
+      }
+      
+      return data;
     }
     return {
       score: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "password-meter",
-  "version": "3.5.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -460,6 +460,16 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -1243,6 +1253,13 @@
       "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk=",
       "dev": true
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1640,7 +1657,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -2838,6 +2859,13 @@
       "resolved": "https://registry.npmjs.org/mute-stdout/-/mute-stdout-1.0.1.tgz",
       "integrity": "sha512-kDcwXR4PS7caBpuRYYBUz9iVixUk3anO3f5OYFiIPwK/20vCzKCHyKoulbiDY1S53zD2bxUpxN/IJ+TnXjfvxg==",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "password-meter",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "This password meter library is inspired by pointing system in http://www.passwordmeter.com/, in which the main purpose is to help the end users to have more stronger passwords.",
   "keywords": [
     "password",


### PR DESCRIPTION
This PR introduces a new argument option to `getResult/getResults` functions, in order to achieve the following ideia:

When a user start typing we want to provide a nice experience to them showing an "security level" bar based on PasswordMeter's `score` data.
But when we define the PasswordMeter instance with some requirements we have only an error showing to user every requirement they missed. 

So the purpose of this option is just to skip requirements validation and return both requirement errors and the generated score.


![image](https://user-images.githubusercontent.com/4116980/104107368-5043e480-529a-11eb-9964-6cdb64bc7c05.png)
